### PR TITLE
Fix incorrect material matching due to substring overlap

### DIFF
--- a/HenryMod/Modules/Materials.cs
+++ b/HenryMod/Modules/Materials.cs
@@ -12,10 +12,11 @@ namespace HenryMod.Modules
         public static Material LoadMaterial(this AssetBundle assetBundle, string materialName) => CreateHopooMaterialFromBundle(assetBundle, materialName);
         public static Material CreateHopooMaterialFromBundle(this AssetBundle assetBundle, string materialName)
         {
+            materialName = materialName.Replace(" (Instance)", "");
             Material tempMat = cachedMaterials.Find(mat =>
             {
-                materialName.Replace(" (Instance)", "");
-                return mat.name.Contains(materialName);
+                string cachedName = mat.name.Replace(" (Instance)", "");
+                return cachedName == materialName;
             });
             if (tempMat) {
                 Log.Debug($"{tempMat.name} has already been loaded. returning cached");


### PR DESCRIPTION
This change prevents incorrect material assignment when material names contain overlapping substrings in CreateHopooMaterialFromBundle.

Previously, using .Contains() could cause the wrong material to be assigned to a mesh. For example, I encountered a case where a hair accessory material (mat_hair_acc) was incorrectly applied to a hair mesh intended to use mat_hair while setting up an alternate character skin.